### PR TITLE
Use another service to encode media path.

### DIFF
--- a/Resources/services.xml
+++ b/Resources/services.xml
@@ -24,7 +24,7 @@
         </service>
 
         <service id="nlxWebPOptimizer\Subscriber\DoctrineSubscriber">
-            <argument type="service" id="shopware_media.media_service"/>
+            <argument type="service" id="shopware_media.strategy"/>
             <tag name="doctrine.event_subscriber"/>
         </service>
     </services>

--- a/Subscriber/DoctrineSubscriber.php
+++ b/Subscriber/DoctrineSubscriber.php
@@ -12,16 +12,16 @@ namespace nlxWebPOptimizer\Subscriber;
 use Doctrine\Common\EventSubscriber;
 use Doctrine\ORM\Event\LifecycleEventArgs;
 use Doctrine\ORM\Events;
-use Shopware\Bundle\MediaBundle\MediaServiceInterface;
+use Shopware\Bundle\MediaBundle\Strategy\StrategyInterface;
 use Shopware\Models\Media\Media;
 
 class DoctrineSubscriber implements EventSubscriber
 {
-    private MediaServiceInterface $mediaService;
+    private StrategyInterface $strategy;
 
-    public function __construct(MediaServiceInterface $mediaService)
+    public function __construct(StrategyInterface $strategy)
     {
-        $this->mediaService = $mediaService;
+        $this->strategy = $strategy;
     }
 
     /**
@@ -53,7 +53,7 @@ class DoctrineSubscriber implements EventSubscriber
 
     private function deleteImage(string $path): void
     {
-        $encodedPath = $this->mediaService->encode($path);
+        $encodedPath = $this->strategy->encode($path);
         $mediaWebpPath = $encodedPath . '.webp';
 
         if (\file_exists($mediaWebpPath)) {

--- a/plugin.xml
+++ b/plugin.xml
@@ -3,7 +3,7 @@
         xsi:noNamespaceSchemaLocation="../../../engine/Shopware/Components/Plugin/schema/plugin.xsd">
     <label lang="de">nlxWebPOptimizer</label>
     <label lang="en">nlxWebPOptimizer</label>
-    <version>1.1.0</version>
+    <version>1.1.1</version>
     <copyright>(c) by netlogix GmbH &amp; Co. KG</copyright>
     <license>Proprietary</license>
     <link>https://websolutions.netlogix.de/</link>
@@ -25,5 +25,9 @@
     <changelog version="1.1.0">
         <changes lang="de">Beim löschen eines Bildes wird auch die WebP Datei gelöscht</changes>
         <changes lang="en">When deleting an image, the WebP file is also deleted</changes>
+    </changelog>
+    <changelog version="1.1.1">
+        <changes lang="de">Benutze einen anderen Service um, dependency Fehler zu vermeiden. Momentan tauchen Fehler auf, wenn in der shopware Config keine "mediaUrl" definiert ist</changes>
+        <changes lang="en">Use another service to avoid dependency errors. Currently, errors occur when no "mediaUrl" is defined in the shopware Config</changes>
     </changelog>
 </plugin>

--- a/spec/Subscriber/DoctrineSubscriberSpec.php
+++ b/spec/Subscriber/DoctrineSubscriberSpec.php
@@ -15,7 +15,6 @@ use nlxWebPOptimizer\Subscriber\DoctrineSubscriber;
 use org\bovigo\vfs\vfsStream;
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
-use Shopware\Bundle\MediaBundle\MediaServiceInterface;
 use Shopware\Bundle\MediaBundle\Strategy\StrategyInterface;
 use Shopware\Models\Article\Article;
 use Shopware\Models\Media\Media;

--- a/spec/Subscriber/DoctrineSubscriberSpec.php
+++ b/spec/Subscriber/DoctrineSubscriberSpec.php
@@ -16,15 +16,16 @@ use org\bovigo\vfs\vfsStream;
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
 use Shopware\Bundle\MediaBundle\MediaServiceInterface;
+use Shopware\Bundle\MediaBundle\Strategy\StrategyInterface;
 use Shopware\Models\Article\Article;
 use Shopware\Models\Media\Media;
 
 class DoctrineSubscriberSpec extends ObjectBehavior
 {
     public function let(
-        MediaServiceInterface $mediaService
+        StrategyInterface $strategy
     ): void {
-        $this->beConstructedWith($mediaService);
+        $this->beConstructedWith($strategy);
     }
 
     public function it_is_initializable(): void
@@ -42,7 +43,7 @@ class DoctrineSubscriberSpec extends ObjectBehavior
     public function it_should_remove_webp_files(
         LifecycleEventArgs $args,
         Media $entity,
-        MediaServiceInterface $mediaService
+        StrategyInterface $strategy
     ): void {
         $structure = [
             'media' => [
@@ -73,10 +74,10 @@ class DoctrineSubscriberSpec extends ObjectBehavior
         $entity->getPath()
             ->willReturn('path/to/123456789.jpg');
 
-        $mediaService->encode('path/to/123456789.jpg')
+        $strategy->encode('path/to/123456789.jpg')
             ->willReturn($root->url() . '/media/image/ab/cd/123456789.jpg');
 
-        $mediaService->encode('path/to/123456789-thumbnail.jpg')
+        $strategy->encode('path/to/123456789-thumbnail.jpg')
             ->willReturn($root->url() . '/media/image/ef/gh/123456789-thumbnail.jpg');
 
         $entity->getThumbnailFilePaths()
@@ -94,12 +95,12 @@ class DoctrineSubscriberSpec extends ObjectBehavior
     public function it_should_do_nothing_if_entity_is_not_media(
         LifecycleEventArgs $args,
         Article $article,
-        MediaServiceInterface $mediaService
+        StrategyInterface $strategy
     ): void {
         $args->getEntity()
             ->willReturn($article);
 
-        $mediaService->encode(Argument::any())
+        $strategy->encode(Argument::any())
             ->shouldNotBeCalled();
 
         $this->postRemove($args);
@@ -108,7 +109,7 @@ class DoctrineSubscriberSpec extends ObjectBehavior
     public function it_should_do_nothing_if_media_is_not_image(
         LifecycleEventArgs $args,
         Media $entity,
-        MediaServiceInterface $mediaService
+        StrategyInterface $strategy
     ): void {
         $args->getEntity()
             ->willReturn($entity);
@@ -116,7 +117,7 @@ class DoctrineSubscriberSpec extends ObjectBehavior
         $entity->getType()
             ->willReturn(Media::TYPE_VECTOR);
 
-        $mediaService->encode(Argument::any())
+        $strategy->encode(Argument::any())
             ->shouldNotBeCalled();
 
         $this->postRemove($args);


### PR DESCRIPTION
At the moment we get following error, if no mediaUrl is defined in shopware config: " WARNING! Circular reference detected for service "models", path: "models -> model_event_manager -> nlxWebPOptimizer\Subscriber\DoctrineSubscriber -> shopware_media.media_service -> front -> plugins -> Shopware\Components\Plugin\Configuration\CachedReader -> Shopware\Components\Plugin\Configuration\Layers\LanguageShopLayer -> models". in /var/www/vendor/symfony/dependency-injection/Container.php" This is because in MediaService he gets the "font" dependency if no 'mediaUrl' is defined